### PR TITLE
Add null checks for horiSeg and vertSeg in both method

### DIFF
--- a/src/me/mars/Bridges.java
+++ b/src/me/mars/Bridges.java
@@ -531,8 +531,8 @@ public class Bridges extends Mod {
 	}
 
 	public static void both(Cons<QuadTree<Segment>> cons) {
-		cons.get(horiSeg);
-		cons.get(vertSeg);
+		if (horiSeg != null) cons.get(horiSeg);
+		if (vertSeg != null) cons.get(vertSeg);
 	}
 
 }


### PR DESCRIPTION
In sector generation, when the engine wants to place a loadout, either some sort of core schematic and whatnot, it places said schematic and it checks for bridges. But because the world hasn't been "loaded", the QuadTrees are null.